### PR TITLE
Replace Metropolis with Vienna in the README

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ CTAN_CONTENT = README.md $(INS) $(PACKAGE_SRC) $(DOC_SRC) $(DOC_PDF) $(DEMO_SRC)
 DESTDIR     ?= $(shell kpsewhich -var-value=TEXMFHOME)
 INSTALL_DIR  = $(DESTDIR)/tex/latex/vienna
 DOC_DIR      = $(DESTDIR)/doc/latex/vienna
-CACHE_DIR   := $(shell pwd)/.latex-cache
+CACHE_DIR   := "$(shell pwd)"/.latex-cache
 
 COMPILE_TEX := latexmk -lualatex -output-directory=$(CACHE_DIR)
 export TEXINPUTS:=$(shell pwd):$(shell pwd)/source:${TEXINPUTS}
@@ -78,4 +78,3 @@ $(DEMO_PDF): $(DEMO_SRC) $(PACKAGE_STY) | clean-cache $(CACHE_DIR)
 demo/demo.png: $(DEMO_PDF) | clean-cache $(CACHE_DIR)
 	pdftoppm $(DEMO_PDF) $(CACHE_DIR)/slides -png -scale-to 1000
 	montage -mode concatenate -tile 2x2 $(CACHE_DIR)/slides-01.png $(CACHE_DIR)/slides-03.png $(CACHE_DIR)/slides-04.png $(CACHE_DIR)/slides-29.png demo/demo.png
-

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Not convinced? Have a look at the [demo slides][] or read the [manual][].
 To install a stable version of this theme, please refer to update instructions
 of your TeX distribution. 
 
-Installing Metropolis from source, like any Beamer theme, involves four easy
+Installing Vienna from source, like any Beamer theme, involves four easy
 steps:
 
 1. **Download the source** with a `git clone` of the [Vienna repository](https://github.com/Findus23/vienna-theme)
@@ -34,7 +34,7 @@ steps:
 2. **Compile the style files** by running `make sty` inside the downloaded
     directory. (Or run LaTeX directly on `source/viennatheme.ins`.)
 3. **Move the resulting `*.sty` files** to the folder containing your
-   presentation. To use Metropolis with many presentations, run `make install`
+   presentation. To use Vienna with many presentations, run `make install`
    or move the `*.sty` files to a folder in your TeX path instead.
 4. **Use the theme for your presentation** by declaring `\usetheme{vienna}` in
     the preamble of your Beamer document.
@@ -44,7 +44,7 @@ steps:
 ## Usage
 
 The following code shows a minimal example of a Beamer presentation using
-Metropolis.
+Vienna.
 
 ```latex
 \documentclass{beamer}
@@ -62,7 +62,7 @@ Metropolis.
 \end{document}
 ```
 
-Detailed information on using Metropolis can be found in the [manual][].
+Detailed information on using Vienna can be found in the [manual][].
 
 
 ## License


### PR DESCRIPTION
This PR replaces a few remaining occurrences of "Metropolis" with "Vienna" in the `README.md` file. It also makes a minor improvement to the `Makefile`, allowing spaces in the path in which the project is stored.